### PR TITLE
Support TypeWrapper and new get_message_fields Service

### DIFF
--- a/src/components/JSONInput.vue
+++ b/src/components/JSONInput.vue
@@ -62,11 +62,7 @@ const is_topic_ref = computed<boolean>(() => {
   if (param.value === undefined) {
     return false
   }
-  const match = param.value.value.type.match(/dict\((.+)\)/)
-  if (match === null) {
-    return false
-  }
-  if (match[1] === 'ros') {
+  if (param.value.value.type === 'dict(ros)') {
     return true
   }
   return false

--- a/src/components/JSONInput.vue
+++ b/src/components/JSONInput.vue
@@ -58,9 +58,26 @@ let editor: JSONEditor | undefined = undefined
 
 // Checks if there is a parameter that could be used to fetch
 // a default value for Ros Messages
-const topic_ref_param = computed<ParamData | undefined>(() => 
-  edit_node_store.new_node_options.find((x) => x.value.type === RosTopicType_Name)
-)
+const is_topic_ref = computed<boolean>(() => {
+  if (param.value === undefined) {
+    return false
+  }
+  const match = param.value.value.type.match(/dict\((.+)\)/)
+  if (match === null) {
+    return false
+  }
+  if (match[1] === 'ros') {
+    return true
+  }
+  return false
+})
+
+const topic_ref_param = computed<ParamData | undefined>(() => {
+  if (!is_topic_ref.value) {
+    return undefined
+  }
+  return edit_node_store.new_node_options.find((x) => x.value.type === RosTopicType_Name)
+})
 
 function onFocus() {
   edit_node_store.changeCopyMode(false)

--- a/src/components/PackageLoader.vue
+++ b/src/components/PackageLoader.vue
@@ -28,16 +28,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  -->
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
-import { useROSStore } from '@/stores/ros'
-import type {
-  GetAvailableNodesRequest,
-  GetAvailableNodesResponse
-} from '@/types/services/GetAvailableNodes'
+import { ref } from 'vue'
 import { useNodesStore } from '@/stores/nodes'
-import { notify } from '@kyvg/vue3-notification'
 
-const ros_store = useROSStore()
+
 const nodes_store = useNodesStore()
 
 const collapsed = ref<boolean>(false)

--- a/src/components/ParamInputs.vue
+++ b/src/components/ParamInputs.vue
@@ -174,7 +174,7 @@ function onFocus() {
     </div>
 
     <TypeParam
-      v-else-if="param.value.type === 'type'"
+      v-else-if="param.value.type.startsWith('type')"
       :category="props.category"
       :data_key="props.data_key"
     />

--- a/src/components/ParamInputs.vue
+++ b/src/components/ParamInputs.vue
@@ -249,11 +249,8 @@ function onFocus() {
       :type="'action'"
     />
 
-    <div v-else class="form-group">
-      <label class="d-block">
-        {{ param.key }}
-        <JSONInput v-bind="json_attrs" :category="props.category" :data_key="props.data_key" />
-      </label>
+    <div v-else class="form-group position-relative">
+      <JSONInput v-bind="json_attrs" :category="props.category" :data_key="props.data_key" />
     </div>
   </div>
   <div v-else>Error loading param data</div>

--- a/src/components/ParamInputs.vue
+++ b/src/components/ParamInputs.vue
@@ -174,7 +174,7 @@ function onFocus() {
     </div>
 
     <TypeParam
-      v-else-if="param.value.type.startsWith('type')"
+      v-else-if="param.value.type === 'type'"
       :category="props.category"
       :data_key="props.data_key"
     />

--- a/src/components/ParamInputs.vue
+++ b/src/components/ParamInputs.vue
@@ -111,24 +111,6 @@ const input_attrs = computed<any>(() => {
   }
 })
 
-// Below gives the attributes for data types handled by <JSONInput>
-//  no type_values check since this is also the fallback
-const json_attrs = computed<any>(() => {
-  if (param.value === undefined) {
-    return undefined
-  }
-  switch (param.value.value.type) {
-    case 'list':
-      break
-    case 'dict':
-    case OrderedDict_Name:
-      break
-    default:
-      break
-  }
-  return {}
-})
-
 // Handles value changes for the <input> element
 function onChange(event: Event) {
   if (param.value === undefined) {
@@ -174,7 +156,7 @@ function onFocus() {
     </div>
 
     <TypeParam
-      v-else-if="param.value.type === 'type'"
+      v-else-if="param.value.type.startsWith('type')"
       :category="props.category"
       :data_key="props.data_key"
     />
@@ -250,7 +232,7 @@ function onFocus() {
     />
 
     <div v-else class="form-group position-relative">
-      <JSONInput v-bind="json_attrs" :category="props.category" :data_key="props.data_key" />
+      <JSONInput :category="props.category" :data_key="props.data_key" />
     </div>
   </div>
   <div v-else>Error loading param data</div>

--- a/src/components/ParamInputs.vue
+++ b/src/components/ParamInputs.vue
@@ -43,7 +43,6 @@ import {
   MathOperandType_Name,
   MathUnaryOperandType_Name,
   MathUnaryOperator_Name,
-  OrderedDict_Name,
   RosTopicType_Name,
   RosTopicName_Name,
   RosServiceType_Name,

--- a/src/components/ParamInputs.vue
+++ b/src/components/ParamInputs.vue
@@ -52,6 +52,7 @@ import {
 } from '@/types/python_types'
 import RosTypeParam from './param_inputs/RosTypeParam.vue'
 import RosNameParam from './param_inputs/RosNameParam.vue'
+import { getTypeAndInfo } from '@/utils'
 
 const props = defineProps<{
   category: 'options'
@@ -65,11 +66,20 @@ const param = computed<ParamData | undefined>(() =>
   edit_node_store.new_node_options.find((x) => x.key === props.data_key)
 )
 
+const param_type = computed<string>(() => {
+  if (param.value === undefined) {
+    return ''
+  }
+  return getTypeAndInfo(param.value.value.type)[0]
+})
+
 // Below lists the data types that are handled by <input>...
 const input_type_values = ['int', 'float', 'bool', 'string', 'unset_optionref']
 //  ...and gives the appropriate attributes.
 const input_attrs = computed<any>(() => {
-  if (param.value === undefined || !input_type_values.includes(param.value.value.type)) {
+  if (param.value === undefined ||
+    !input_type_values.includes(param_type.value)
+  ) {
     return undefined
   }
   let type: string,
@@ -78,7 +88,7 @@ const input_attrs = computed<any>(() => {
     cssclass: string[] = ['form-control'],
     checked: boolean = false,
     disabled: boolean = editor_store.selected_subtree.is_subtree
-  switch (param.value.value.type) {
+  switch (param_type.value) {
     case 'int':
       step = 1.0
     case 'float':
@@ -155,76 +165,76 @@ function onFocus() {
     </div>
 
     <TypeParam
-      v-else-if="param.value.type.startsWith('type')"
+      v-else-if="param_type === 'type'"
       :category="props.category"
       :data_key="props.data_key"
     />
     
     <MathOperatorParam
-      v-else-if="param.value.type === MathUnaryOperator_Name"
+      v-else-if="param_type === MathUnaryOperator_Name"
       :category="props.category"
       :data_key="props.data_key"
       :op_type="'unary'"
     />
     <MathOperandParam
-      v-else-if="param.value.type === MathUnaryOperandType_Name"
+      v-else-if="param_type === MathUnaryOperandType_Name"
       :category="props.category"
       :data_key="props.data_key"
       :op_type="'unary'"
     />
     <MathOperatorParam
-      v-else-if="param.value.type === MathBinaryOperator_Name"
+      v-else-if="param_type === MathBinaryOperator_Name"
       :category="props.category"
       :data_key="props.data_key"
       :op_type="'binary'"
     />
     <MathOperandParam
-      v-else-if="param.value.type === MathOperandType_Name"
+      v-else-if="param_type === MathOperandType_Name"
       :category="props.category"
       :data_key="props.data_key"
       :op_type="'binary'"
     />
 
     <FilePathParam
-      v-else-if="param.value.type === FilePath_Name"
+      v-else-if="param_type === FilePath_Name"
       :category="props.category"
       :data_key="props.data_key"
     />
 
     <RosTypeParam
-      v-else-if="param.value.type === RosTopicType_Name"
+      v-else-if="param_type === RosTopicType_Name"
       :category="props.category"
       :data_key="props.data_key"
       :type="'topic'"
     />
     <RosNameParam
-      v-else-if="param.value.type === RosTopicName_Name"
+      v-else-if="param_type === RosTopicName_Name"
       :category="props.category"
       :data_key="props.data_key"
       :type="'topic'"
     />
 
     <RosTypeParam
-      v-else-if="param.value.type === RosServiceType_Name"
+      v-else-if="param_type === RosServiceType_Name"
       :category="props.category"
       :data_key="props.data_key"
       :type="'service'"
     />
     <RosNameParam
-      v-else-if="param.value.type === RosServiceName_Name"
+      v-else-if="param_type === RosServiceName_Name"
       :category="props.category"
       :data_key="props.data_key"
       :type="'service'"
     />
 
     <RosTypeParam
-      v-else-if="param.value.type === RosActionType_Name"
+      v-else-if="param_type === RosActionType_Name"
       :category="props.category"
       :data_key="props.data_key"
       :type="'action'"
     />
     <RosNameParam
-      v-else-if="param.value.type === RosActionName_Name"
+      v-else-if="param_type === RosActionName_Name"
       :category="props.category"
       :data_key="props.data_key"
       :type="'action'"

--- a/src/components/TreeNameStateDisplay.vue
+++ b/src/components/TreeNameStateDisplay.vue
@@ -58,7 +58,7 @@ const tree_state = computed<TreeState>(() => {
 
 const tree_state_styles = computed<any>(() => {
   let bg_color_var = ''
-  let border_color_var = '--bs-body-color'
+  //let border_color_var = '--bs-body-color'
   switch (tree_state.value) {
     case TreeState.ERROR:
       bg_color_var = '--bg-color-error'

--- a/src/components/param_inputs/TypeParam.vue
+++ b/src/components/param_inputs/TypeParam.vue
@@ -32,7 +32,7 @@ import { useEditNodeStore } from '@/stores/edit_node'
 import { useEditorStore } from '@/stores/editor'
 import { useMessasgeStore } from '@/stores/message'
 import type { ParamData } from '@/types/types'
-import { python_builtin_types } from '@/utils'
+import { getTypeAndInfo, python_builtin_types } from '@/utils'
 import Fuse from 'fuse.js'
 import { computed, ref } from 'vue'
 
@@ -55,11 +55,8 @@ const search_fuse = computed<Fuse<string>>(() => {
   if (param.value === undefined) {
     return messages_store.messages_fuse
   }
-  const match = param.value.value.type.match(/type\((.+)\)/)
-  if (match === null) {
-    return messages_store.messages_fuse
-  }
-  if (match[1] === 'builtin') {
+  const info = getTypeAndInfo(param.value.value.type)[1]
+  if (info === 'builtin') {
     return new Fuse<string>(python_builtin_types)
   }
   return messages_store.messages_fuse

--- a/src/components/param_inputs/TypeParam.vue
+++ b/src/components/param_inputs/TypeParam.vue
@@ -31,7 +31,6 @@
 import { useEditNodeStore } from '@/stores/edit_node'
 import { useEditorStore } from '@/stores/editor'
 import { useMessasgeStore } from '@/stores/message'
-import { HintedType_Name } from '@/types/python_types'
 import type { ParamData } from '@/types/types'
 import { python_builtin_types } from '@/utils'
 import Fuse from 'fuse.js'
@@ -52,27 +51,15 @@ const param = computed<ParamData | undefined>(() =>
   edit_node_store.new_node_options.find((x) => x.key === props.data_key)
 )
 
-const type_hints = computed<string[]>(() => {
-  if (edit_node_store.reference_node === undefined) {
-    console.warn("Ref node unset")
-    return []
-  }
-  const ref_option = edit_node_store.reference_node.options.find(
-    (x) => x.key === props.data_key
-  )
-  if (ref_option === undefined) {
-    console.warn("Invalid option key")
-    return []
-  }
-  const ref_data = JSON.parse(ref_option.serialized_value)
-  if (ref_data['py/object'] === HintedType_Name) {
-    return ref_data['hints']
-  }
-  return []
-})
-
 const search_fuse = computed<Fuse<string>>(() => {
-  if (type_hints.value.includes('builtin')) {
+  if (param.value === undefined) {
+    return messages_store.messages_fuse
+  }
+  const match = param.value.value.type.match(/type\((.+)\)/)
+  if (match === null) {
+    return messages_store.messages_fuse
+  }
+  if (match[1] === 'builtin') {
     return new Fuse<string>(python_builtin_types)
   }
   return messages_store.messages_fuse

--- a/src/stores/edit_node.ts
+++ b/src/stores/edit_node.ts
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { NodeState, type DocumentedNode, type NodeData, type NodeMsg, type ParamData, type ValueTypes } from '@/types/types'
+import { NodeState, TreeState, type DocumentedNode, type NodeData, type NodeMsg, type ParamData, type ValueTypes } from '@/types/types'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { useEditorStore } from './editor'

--- a/src/stores/edit_node.ts
+++ b/src/stores/edit_node.ts
@@ -193,8 +193,8 @@ export const useEditNodeStore = defineStore('edit_node', () => {
     function getValues(x: NodeData): ParamData {
       const type = prettyprint_type(x.serialized_type)
       let json_value = JSON.parse(x.serialized_value)
-      if (type === 'type') {
-        json_value = json_value['py/type']
+      if (type.startsWith('type')) {
+        json_value = prettyprint_type(x.serialized_value)
       }
       return {
         key: x.key,

--- a/src/stores/edit_node.ts
+++ b/src/stores/edit_node.ts
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import type { DocumentedNode, NodeData, NodeMsg, ParamData, ValueTypes } from '@/types/types'
+import { NodeState, type DocumentedNode, type NodeData, type NodeMsg, type ParamData, type ValueTypes } from '@/types/types'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { useEditorStore } from './editor'
@@ -379,7 +379,7 @@ export const useEditNodeStore = defineStore('edit_node', () => {
       inputs: [],
       outputs: [],
       version: '',
-      state: ''
+      state: NodeState.UNINITIALIZED
     }
   }
 

--- a/src/stores/edit_node.ts
+++ b/src/stores/edit_node.ts
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { NodeState, TreeState, type DocumentedNode, type NodeData, type NodeMsg, type ParamData, type ValueTypes } from '@/types/types'
+import type { DocumentedNode, NodeData, NodeMsg, ParamData, ValueTypes } from '@/types/types'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { useEditorStore } from './editor'
@@ -379,7 +379,7 @@ export const useEditNodeStore = defineStore('edit_node', () => {
       inputs: [],
       outputs: [],
       version: '',
-      state: NodeState.UNINITIALIZED
+      state: ''
     }
   }
 

--- a/src/types/python_types.ts
+++ b/src/types/python_types.ts
@@ -32,7 +32,11 @@ import type { PyObject, PyReduce } from './types'
 
 const PyDefaultValues = new Map<string, PyObject | PyReduce>()
 
-export const HintedType_Name = 'ros_bt_py.custom_types.HintedType'
+export type TypeWrapper = PyObject & {
+  actual_type: string
+  info: string
+}
+export const TypeWrapper_Name = 'ros_bt_py.custom_types.TypeWrapper'
 
 export const OrderedDict_Name = 'collections.OrderedDict'
 PyDefaultValues.set(OrderedDict_Name, {

--- a/src/types/python_types.ts
+++ b/src/types/python_types.ts
@@ -32,6 +32,8 @@ import type { PyObject, PyReduce } from './types'
 
 const PyDefaultValues = new Map<string, PyObject | PyReduce>()
 
+export const HintedType_Name = 'ros_bt_py.custom_types.HintedType'
+
 export const OrderedDict_Name = 'collections.OrderedDict'
 PyDefaultValues.set(OrderedDict_Name, {
   'py/reduce': [{ 'py/type': OrderedDict_Name }, { 'py/tuple': [[]] }, null, null, null]

--- a/src/types/services/GetMessageFields.ts
+++ b/src/types/services/GetMessageFields.ts
@@ -30,14 +30,11 @@
 
 export type GetMessageFieldsRequest = {
   message_type: string
-  service: boolean
-  action: boolean
-  type: number
 }
 
 export type GetMessageFieldsResponse = {
   fields: string
-  field_names: string[]
+  field_types: string
   success: boolean
   error_message: string
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-import { getPythonTypeDefault, isPythonTypeWithDefault } from './types/python_types'
+import { getPythonTypeDefault, HintedType_Name, isPythonTypeWithDefault } from './types/python_types'
 import type { 
   NodeData, 
   TreeMsg, 
@@ -69,8 +69,6 @@ export function typesCompatible(a: DataEdgeTerminal, b: DataEdgeTerminal) {
   return prettyprint_type(from.type) === prettyprint_type(to.type)
 }
 
-//TODO This appears to be wrong or outdated.
-// How do we want to handle unsupported types?
 export const python_builtin_types = [
   'int',
   'float',
@@ -82,7 +80,7 @@ export const python_builtin_types = [
   'list',
   'dict',
   'set',
-  'type'
+  'type' //TODO Is this reasonable to allow?
 ]
 
 export function prettyprint_type(jsonpickled_type: string) {
@@ -113,7 +111,7 @@ export function prettyprint_type(jsonpickled_type: string) {
   // Fully hide HintedType, the Typeparam recovers hints on its own
   if (
     json_type['py/object'] !== undefined &&
-    json_type['py/object'] === 'ros_bt_py.custom_types.HintedType'
+    json_type['py/object'] === HintedType_Name
   ) {
     return 'type'
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,6 +111,13 @@ export function prettyprint_type(jsonpickled_type: string) {
   }
 
   if (
+    json_type['py/object'] !== undefined &&
+    json_type['py/object'] === 'ros_bt_py.custom_types.HintedType'
+  ) {
+    return 'type(' + json_type['hints'] + ')'
+  }
+
+  if (
     json_type['py/reduce'] !== undefined &&
     json_type['py/reduce'][0] !== undefined &&
     json_type['py/reduce'][0]['py/type'] !== undefined &&
@@ -126,9 +133,9 @@ export function getDefaultValue(
   typeName: string,
   options: NodeData[] | null = null
 ): ParamType {
-  if (typeName === 'type') {
+  if (typeName.startsWith('type')) {
     return {
-      type: 'type',
+      type: typeName,
       value: 'int'
     }
   } else if (typeName === 'int' || typeName === 'long') {
@@ -214,7 +221,7 @@ export function serializeNodeOptions(node_options: ParamData[]): NodeData[] {
       serialized_value: '',
       serialized_type: '' // This is left blank intentionally
     }
-    if (x.value.type === 'type') {
+    if (x.value.type.startsWith('type')) {
       if (python_builtin_types.indexOf(x.value.value as string) >= 0) {
         x.value.value = 'builtins.' + x.value.value;
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,48 +136,57 @@ export function prettyprint_type(jsonpickled_type: string): string {
   return 'Unknown type object: ' + jsonpickled_type
 }
 
+export function getTypeAndInfo(typeStr: string): [string, string] {
+  let match
+  if (typeStr.startsWith('OptionRef(')) {
+    match = typeStr.match(/(.*\(.*\))\((.*)\)/)
+  } else {
+    match = typeStr.match(/(.*)\((.*)\)/)
+  }
+  if (match === null) {
+    return [typeStr, '']
+  }
+  return [match[1], match[2]]
+}
+
 export function getDefaultValue(
-  typeName: string,
+  typeStr: string,
   options: NodeData[] | null = null
 ): ParamType {
-  if (typeName.startsWith('type')) {
+  const typeName = getTypeAndInfo(typeStr)[0]
+  if (typeName === 'type') {
     return {
-      type: typeName,
+      type: typeStr,
       value: 'int'
     }
-  } else if (typeName === 'int' || typeName === 'long') {
+  } else if (typeName === 'int') {
     return {
-      type: 'int',
+      type: typeStr,
       value: 0
     }
-  } else if (
-    typeName === 'str' ||
-    typeName === 'basestring' ||
-    typeName === 'unicode' ||
-    typeName === 'string'
-  ) {
+  } else if (typeName === 'string') {
     return {
-      type: 'string',
+      type: typeStr,
       value: 'foo'
     }
   } else if (typeName === 'float') {
     return {
-      type: 'float',
+      type: typeStr,
       value: 1.2
     }
   } else if (typeName === 'bool') {
     return {
-      type: 'bool',
+      type: typeStr,
       value: true
     }
   } else if (typeName === 'list') {
     return {
-      type: 'list',
+      type: typeStr,
       value: []
     }
-  } else if (typeName.startsWith('dict')) {
+  } else if (typeName === 'dict') {
     return {
-      type: typeName,
+      type: typeStr,
       value: {}
     }
   } else if (typeName.startsWith('OptionRef(')) {
@@ -210,12 +219,12 @@ export function getDefaultValue(
   // which provide default values
   } else if (isPythonTypeWithDefault(typeName)) {
     return {
-      type: typeName,
+      type: typeStr,
       value: getPythonTypeDefault(typeName) || {}
     }
   } else {
     return {
-      type: '__' + typeName,
+      type: '__' + typeStr,
       value: {}
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,11 +110,12 @@ export function prettyprint_type(jsonpickled_type: string) {
     return 'OptionRef(' + json_type['option_key'] + ')'
   }
 
+  // Fully hide HintedType, the Typeparam recovers hints on its own
   if (
     json_type['py/object'] !== undefined &&
     json_type['py/object'] === 'ros_bt_py.custom_types.HintedType'
   ) {
-    return 'type(' + json_type['hints'] + ')'
+    return 'type'
   }
 
   if (
@@ -133,9 +134,9 @@ export function getDefaultValue(
   typeName: string,
   options: NodeData[] | null = null
 ): ParamType {
-  if (typeName.startsWith('type')) {
+  if (typeName === 'type') {
     return {
-      type: typeName,
+      type: 'type',
       value: 'int'
     }
   } else if (typeName === 'int' || typeName === 'long') {
@@ -221,7 +222,7 @@ export function serializeNodeOptions(node_options: ParamData[]): NodeData[] {
       serialized_value: '',
       serialized_type: '' // This is left blank intentionally
     }
-    if (x.value.type.startsWith('type')) {
+    if (x.value.type === 'type') {
       if (python_builtin_types.indexOf(x.value.value as string) >= 0) {
         x.value.value = 'builtins.' + x.value.value;
       }


### PR DESCRIPTION
The TypeWrapper is generally treated as identical with its inner type.

The additional info is handled by the respective param field, 
or ignored if there is no specific behavior associated with it.

This is dependant on
https://github.com/fzi-forschungszentrum-informatik/ros2_ros_bt_py/pull/159

Closes https://github.com/fzi-forschungszentrum-informatik/ros2_ros_bt_py_web_gui/issues/8