### PR TITLE
Quick save feature

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -47,7 +47,8 @@ import NewNode from './components/NewNode.vue'
 import SelectedNode from './components/SelectedNode.vue'
 import TreeNameStateDisplay from './components/TreeNameStateDisplay.vue'
 import EditorDisplayButtons from './components/EditorDisplayButtons.vue'
-import LoadSaveControls from './components/LoadSaveControls.vue'
+import LoadSaveClient from './components/LoadSaveClient.vue'
+import LoadSaveServer from './components/LoadSaveServer.vue'
 import NamespaceSelect from './components/NamespaceSelect.vue'
 import TickControls from './components/TickControls.vue'
 import NodeQuickSelect from './components/NodeQuickSelect.vue'
@@ -196,12 +197,14 @@ onMounted(() => {
     class="d-flex justify-content-between align-items-center w-100 p-2 top-bar"
   >
     
-      <ConnectionStatus />
+    <ConnectionStatus />
 
-      <TickControls />
+    <TickControls />
 
-      <LoadSaveControls />
-
+    <div class="btn-group">
+      <LoadSaveServer />
+      <LoadSaveClient />
+    </div>
   </header>
 
   <main>

--- a/src/components/LoadSaveClient.vue
+++ b/src/components/LoadSaveClient.vue
@@ -288,7 +288,7 @@ function saveTree() {
   <button
     class="btn btn-primary btn-spaced"
     title="Upload"
-    :disabled="editor_store.selected_subtree.is_subtree"
+    :disabled="editor_store.has_selected_subtree"
     @click="openFileDialog"
   >
     <FontAwesomeIcon icon="fa-solid fa-file-upload" aria-hidden="true" />
@@ -297,7 +297,7 @@ function saveTree() {
   <button
     class="btn btn-primary btn-spaced"
     title="Download"
-    :disabled="editor_store.selected_subtree.is_subtree"
+    :disabled="editor_store.has_selected_subtree"
     @click="saveTree"
   >
     <FontAwesomeIcon icon="fa-solid fa-file-download" aria-hidden="true" />

--- a/src/components/LoadSaveClient.vue
+++ b/src/components/LoadSaveClient.vue
@@ -1,5 +1,5 @@
 <!--
- *  Copyright 2024 FZI Forschungszentrum Informatik
+ *  Copyright 2025 FZI Forschungszentrum Informatik
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -26,25 +26,17 @@
  *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
- -->
+-->
 <script setup lang="ts">
-import { useROSStore } from '@/stores/ros'
-import type { ClearTreeRequest, ClearTreeResponse } from '@/types/services/ClearTree'
-import { notify } from '@kyvg/vue3-notification'
-import { ref } from 'vue'
-import { useModal } from 'vue-final-modal'
-import SaveFileModal from './modals/SaveFileModal.vue'
-import LoadFileModal from './modals/LoadFileModal.vue'
-import { useEditorStore } from '@/stores/editor'
-import {
-  TreeExecutionCommands,
-  type ControlTreeExecutionRequest,
-  type ControlTreeExecutionResponse
-} from '@/types/services/ControlTreeExecution'
+import { useEditorStore } from '@/stores/editor';
+import { useROSStore } from '@/stores/ros';
+import { notify } from '@kyvg/vue3-notification';
+import { ref } from 'vue';
 import jsyaml from 'js-yaml'
 import type { LoadTreeRequest, LoadTreeResponse } from '@/types/services/LoadTree'
 import type { TreeStructure } from '@/types/types'
 import type { FixYamlRequest, FixYamlResponse } from '@/types/services/FixYaml'
+import { TreeExecutionCommands, type ControlTreeExecutionRequest, type ControlTreeExecutionResponse } from '@/types/services/ControlTreeExecution';
 
 const ros_store = useROSStore()
 const editor_store = useEditorStore()
@@ -52,134 +44,6 @@ const editor_store = useEditorStore()
 const file_input_ref = ref<HTMLInputElement>()
 
 const file_reader = new FileReader()
-
-const loadPackageModalHandle = useModal({
-  component: LoadFileModal,
-  attrs: {
-    fromPackages: true,
-    onClose() {
-      loadPackageModalHandle.close()
-    }
-  }
-})
-
-const loadFileModalHandle = useModal({
-  component: LoadFileModal,
-  attrs: {
-    fromPackages: false,
-    onClose() {
-      loadFileModalHandle.close()
-    }
-  }
-})
-
-const saveFileModalHandle = useModal({
-  component: SaveFileModal,
-  attrs: {
-    onClose() {
-      saveFileModalHandle.close()
-    }
-  }
-})
-
-function newTree() {
-  if (ros_store.clear_tree_service === undefined) {
-    notify({
-      title: 'Service not available!',
-      text: 'ClearTree ROS service not available.',
-      type: 'error'
-    })
-    return
-  }
-  if (
-    window.confirm(
-      'Do you want to create a new tree? Warning: This will discard the tree that is loaded at the moment.'
-    )
-  ) {
-    ros_store.clear_tree_service.callService(
-      {} as ClearTreeRequest,
-      (response: ClearTreeResponse) => {
-        if (response.success) {
-          console.log('called ClearTree service successfully')
-          notify({
-            title: 'Created new tree successfully!',
-            type: 'success'
-          })
-        } else {
-          notify({
-            title: 'Could not create new tree!',
-            type: 'warn',
-            text: response.error_message
-          })
-        }
-      },
-      (failed: string) => {
-        notify({
-          title: 'ClearTree service call failed!',
-          type: 'error',
-          text: failed
-        })
-      }
-    )
-  }
-}
-
-function loadFromPackage() {
-  loadPackageModalHandle.open()
-}
-
-function loadFromFile() {
-  loadFileModalHandle.open()
-}
-
-function saveToFile() {
-  if (ros_store.control_tree_execution_service === undefined) {
-    notify({
-      title: 'Service not available!',
-      text: 'ControlTreeExecution ROS service is not connected.',
-      type: 'error'
-    })
-    return
-  }
-  editor_store.runNewCommand(TreeExecutionCommands.SHUTDOWN)
-  ros_store.control_tree_execution_service.callService(
-    {
-      command: TreeExecutionCommands.SHUTDOWN
-    } as ControlTreeExecutionRequest,
-    (response: ControlTreeExecutionResponse) => {
-      editor_store.removeRunningCommand(TreeExecutionCommands.SHUTDOWN)
-      if (response.success) {
-        notify({
-          title: 'Tree shutdown successful!',
-          type: 'success'
-        })
-        saveFileModalHandle.open()
-      } else {
-        notify({
-          title: 'Failed to shutdown tree, cannot save now!',
-          text: response.error_message,
-          type: 'warn'
-        })
-      }
-    },
-    (failed: string) => {
-      notify({
-        title: 'Calling ControlTreeExecution ROS service failed!',
-        text: failed,
-        type: 'error'
-      })
-    }
-  )
-}
-
-function downloadURI(uri: string, name: string) {
-  const link = document.createElement('a')
-  link.download = name
-  link.href = uri
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-}
 
 function loadTree(event: Event) {
   const target = event.target as HTMLInputElement
@@ -195,12 +59,13 @@ function loadTree(event: Event) {
   file_reader.readAsText(target.files[0])
 }
 
-function openFileDialog() {
-  if (file_input_ref.value === undefined) {
-    console.error('Fileref is undefined!')
-    return
-  }
-  file_input_ref.value.click()
+function downloadURI(uri: string, name: string) {
+  const link = document.createElement('a')
+  link.download = name
+  link.href = uri
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
 }
 
 function loadTreeMsg(msg: TreeStructure) {
@@ -224,6 +89,7 @@ function loadTreeMsg(msg: TreeStructure) {
           title: 'Loaded tree successfully!',
           type: 'success'
         })
+        editor_store.resetQuickSaveLocation()
       } else {
         if (
           response.error_message.startsWith(
@@ -261,6 +127,7 @@ function loadTreeMsg(msg: TreeStructure) {
                     title: 'Loaded tree successfully!',
                     type: 'success'
                   })
+                  editor_store.resetQuickSaveLocation()
                 } else {
                   notify({
                     title: 'Failed to load tree!',
@@ -294,6 +161,14 @@ function loadTreeMsg(msg: TreeStructure) {
       })
     }
   )
+}
+
+function openFileDialog() {
+  if (file_input_ref.value === undefined) {
+    console.error('Fileref is undefined!')
+    return
+  }
+  file_input_ref.value.click()
 }
 
 function handleFileRead() {
@@ -405,85 +280,29 @@ function saveTree() {
     }
   )
 }
+
 </script>
 
 <template>
-  <div class="btn-group">
-    <button
-      class="btn btn-primary"
-      title="New tree"
-      :disabled="editor_store.has_selected_subtree"
-      @click="() => newTree()"
-    >
-      <FontAwesomeIcon icon="fa-solid fa-file" aria-hidden="true" />
-      <span class="ms-1 hide-button-text">New</span>
-    </button>
-    <div class="btn-group btn-spaced" role="group">
-      <button
-        id="btnGroupDrop1"
-        type="button"
-        class="btn btn-primary dropdown-toggle"
-        data-bs-toggle="dropdown"
-        aria-expanded="false"
-        :disabled="editor_store.has_selected_subtree"
-      >
-        <FontAwesomeIcon icon="fa-solid fa-folder" aria-hidden="true" />
-        <span class="ms-1 hide-button-text">Load</span>
-      </button>
-      <ul class="dropdown-menu" aria-labelledby="btnGroupDrop1">
-        <li>
-          <button
-            class="dropdown-item btn btn-primary"
-            title="Load from package"
-            :disabled="editor_store.has_selected_subtree"
-            @click="() => loadFromPackage()"
-          >
-            <FontAwesomeIcon icon="fa-solid fa-folder-tree" aria-hidden="true" />
-            <span class="ms-1">Package</span>
-          </button>
-        </li>
-        <li>
-          <button
-            class="dropdown-item btn btn-primary"
-            title="Load from file"
-            :disabled="editor_store.has_selected_subtree"
-            @click="() => loadFromFile()"
-          >
-            <FontAwesomeIcon icon="fa-solid fa-folder-open" aria-hidden="true" />
-            <span className="ms-1">File</span>
-          </button>
-        </li>
-      </ul>
-    </div>
-    <button
-      class="btn btn-primary btn-spaced"
-      title="Save to remote"
-      :disabled="editor_store.has_selected_subtree"
-      @click="() => saveToFile()"
-    >
-      <FontAwesomeIcon icon="fa-solid fa-save" aria-hidden="true" />
-      <span class="ms-1 hide-button-text">Save</span>
-    </button>
-    <input ref="file_input_ref" type="file" class="file_input_ref" @change="loadTree" />
-    <button
-      class="btn btn-primary btn-spaced"
-      title="Upload"
-      :disabled="editor_store.has_selected_subtree"
-      @click="() => openFileDialog()"
-    >
-      <FontAwesomeIcon icon="fa-solid fa-file-upload" aria-hidden="true" />
-      <span class="ms-1 hide-button-text">Upload</span>
-    </button>
-    <button
-      class="btn btn-primary btn-spaced"
-      title="Download"
-      :disabled="editor_store.has_selected_subtree"
-      @click="() => saveTree()"
-    >
-      <FontAwesomeIcon icon="fa-solid fa-file-download" aria-hidden="true" />
-      <span class="ms-1 hide-button-text">Download</span>
-    </button>
-  </div>
+  <input ref="file_input_ref" type="file" class="file_input_ref" @change="loadTree" />
+  <button
+    class="btn btn-primary btn-spaced"
+    title="Upload"
+    :disabled="editor_store.selected_subtree.is_subtree"
+    @click="openFileDialog"
+  >
+    <FontAwesomeIcon icon="fa-solid fa-file-upload" aria-hidden="true" />
+    <span class="ms-1 hide-button-text">Upload</span>
+  </button>
+  <button
+    class="btn btn-primary btn-spaced"
+    title="Download"
+    :disabled="editor_store.selected_subtree.is_subtree"
+    @click="saveTree"
+  >
+    <FontAwesomeIcon icon="fa-solid fa-file-download" aria-hidden="true" />
+    <span class="ms-1 hide-button-text">Download</span>
+  </button>
 </template>
 
 <style scoped lang="scss">

--- a/src/components/LoadSaveServer.vue
+++ b/src/components/LoadSaveServer.vue
@@ -51,8 +51,11 @@ const storage_folders = ref<string[]>([])
 
 const quick_save_location = computed<[string, string]>(() => {
   let quick_save_path = editor_store.quick_save_location
-  if (quick_save_path === '' && editor_store.tree !== undefined) {
-    quick_save_path = editor_store.tree.path
+  const tree = editor_store.tree_structure_list.find(
+    (tree) => tree.tree_id === ""
+  )
+  if (quick_save_path === '' && tree !== undefined) {
+    quick_save_path = tree.path
   }
   if (quick_save_path === '' || !quick_save_path.startsWith('file://')) {
     return ['', '']
@@ -199,10 +202,13 @@ function quickSave() {
   if (!window.confirm(`Do you want to overwrite ${quick_save_location.value[0]}/${quick_save_location.value[1]}?`)) {
     return
   }
+  const tree = editor_store.tree_structure_list.find(
+    (tree) => tree.tree_id === ""
+  )
   ros_store.save_tree_service.callService({
     storage_path: quick_save_location.value[0],
     filepath: quick_save_location.value[1],
-    tree: editor_store.tree,
+    tree: tree,
     allow_overwrite: true,
     allow_rename: false,
   } as SaveTreeRequest,
@@ -256,8 +262,8 @@ onMounted(() => {
   <button
     class="btn btn-primary"
     title="New tree"
-    :disabled="editor_store.selected_subtree.is_subtree"
-    @click="() => newTree()"
+    :disabled="editor_store.has_selected_subtree"
+    @click="newTree"
   >
     <FontAwesomeIcon icon="fa-solid fa-file" aria-hidden="true" />
     <span class="ms-1 hide-button-text">New</span>
@@ -269,7 +275,7 @@ onMounted(() => {
       class="btn btn-primary dropdown-toggle"
       data-bs-toggle="dropdown"
       aria-expanded="false"
-      :disabled="editor_store.selected_subtree.is_subtree"
+      :disabled="editor_store.has_selected_subtree"
     >
       <FontAwesomeIcon icon="fa-solid fa-folder" aria-hidden="true" />
       <span class="ms-1 hide-button-text">Load</span>
@@ -279,8 +285,8 @@ onMounted(() => {
         <button
           class="dropdown-item btn btn-primary"
           title="Load from package"
-          :disabled="editor_store.selected_subtree.is_subtree"
-          @click="() => loadFromPackage()"
+          :disabled="editor_store.has_selected_subtree"
+          @click="loadFromPackage"
         >
           <FontAwesomeIcon icon="fa-solid fa-folder-tree" aria-hidden="true" />
           <span class="ms-1">Package</span>
@@ -290,8 +296,8 @@ onMounted(() => {
         <button
           class="dropdown-item btn btn-primary"
           title="Load from file"
-          :disabled="editor_store.selected_subtree.is_subtree"
-          @click="() => loadFromFile()"
+          :disabled="editor_store.has_selected_subtree"
+          @click="loadFromFile"
         >
           <FontAwesomeIcon icon="fa-solid fa-folder-open" aria-hidden="true" />
           <span className="ms-1">File</span>
@@ -302,7 +308,7 @@ onMounted(() => {
   <button
     class="btn btn-primary btn-spaced"
     title="Quick Save to remote"
-    :disabled="editor_store.selected_subtree.is_subtree || quick_save_disable"
+    :disabled="editor_store.has_selected_subtree || quick_save_disable"
     @click="quickSave"
   >
     <!--<FontAwesomeIcon icon="fa-regular fa-save" />-->
@@ -312,8 +318,8 @@ onMounted(() => {
   <button
     class="btn btn-primary btn-spaced"
     title="Save to remote"
-    :disabled="editor_store.selected_subtree.is_subtree"
-    @click="() => saveToFile()"
+    :disabled="editor_store.has_selected_subtree"
+    @click="saveToFile"
   >
     <FontAwesomeIcon icon="fa-solid fa-save" aria-hidden="true" />
     <span class="ms-1 hide-button-text">Save</span>

--- a/src/components/LoadSaveServer.vue
+++ b/src/components/LoadSaveServer.vue
@@ -1,0 +1,290 @@
+<!--
+ *  Copyright 2024 FZI Forschungszentrum Informatik
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *     * Neither the name of the {copyright_holder} nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+-->
+<script setup lang="ts">
+import { useROSStore } from '@/stores/ros'
+import type { ClearTreeRequest, ClearTreeResponse } from '@/types/services/ClearTree'
+import { notify } from '@kyvg/vue3-notification'
+import { useModal } from 'vue-final-modal'
+import SaveFileModal from './modals/SaveFileModal.vue'
+import LoadFileModal from './modals/LoadFileModal.vue'
+import { useEditorStore } from '@/stores/editor'
+import {
+  TreeExecutionCommands,
+  type ControlTreeExecutionRequest,
+  type ControlTreeExecutionResponse
+} from '@/types/services/ControlTreeExecution'
+import { computed, onMounted, ref } from 'vue'
+import type { GetStorageFoldersRequest, GetStorageFoldersResponse } from '@/types/services/GetStorageFolders'
+
+const ros_store = useROSStore()
+const editor_store = useEditorStore()
+
+const storage_folders = ref<string[]>([])
+
+const quick_save_location = computed<[string, string]>(() => {
+  let quick_save_path = editor_store.quick_save_location
+  if (quick_save_path === '' && editor_store.tree !== undefined) {
+    quick_save_path = editor_store.tree.path
+  }
+  if (quick_save_path === '' || !quick_save_path.startsWith('file://')) {
+    return ['', '']
+  }
+  quick_save_path = quick_save_path.replace('file://', '')
+  const location = storage_folders.value.find(
+    (loc) => quick_save_path.startsWith(loc + '/')
+  )
+  if (location === undefined) {
+    return ['', '']
+  }
+  return [location, quick_save_path.replace(location + '/', '')]
+})
+
+const quick_save_disable = computed<boolean>(() => {
+  return quick_save_location.value[0] === '' ||
+    quick_save_location.value[1] === ''
+})
+
+const loadPackageModalHandle = useModal({
+  component: LoadFileModal,
+  attrs: {
+    fromPackages: true,
+    onClose() {
+      loadPackageModalHandle.close()
+    }
+  }
+})
+
+const loadFileModalHandle = useModal({
+  component: LoadFileModal,
+  attrs: {
+    fromPackages: false,
+    onClose() {
+      loadFileModalHandle.close()
+    }
+  }
+})
+
+const saveFileModalHandle = useModal({
+  component: SaveFileModal,
+  attrs: {
+    onClose() {
+      saveFileModalHandle.close()
+    }
+  }
+})
+
+function newTree() {
+  if (ros_store.clear_tree_service === undefined) {
+    notify({
+      title: 'Service not available!',
+      text: 'ClearTree ROS service not available.',
+      type: 'error'
+    })
+    return
+  }
+  if (
+    window.confirm(
+      'Do you want to create a new tree? Warning: This will discard the tree that is loaded at the moment.'
+    )
+  ) {
+    ros_store.clear_tree_service.callService(
+      {} as ClearTreeRequest,
+      (response: ClearTreeResponse) => {
+        if (response.success) {
+          console.log('called ClearTree service successfully')
+          notify({
+            title: 'Created new tree successfully!',
+            type: 'success'
+          })
+          editor_store.resetQuickSaveLocation()
+        } else {
+          notify({
+            title: 'Could not create new tree!',
+            type: 'warn',
+            text: response.error_message
+          })
+        }
+      },
+      (failed) => {
+        notify({
+          title: 'ClearTree service call failed!',
+          type: 'error',
+          text: failed
+        })
+      }
+    )
+  }
+}
+
+function loadFromPackage() {
+  loadPackageModalHandle.open()
+}
+
+function loadFromFile() {
+  loadFileModalHandle.open()
+}
+
+function saveToFile() {
+  if (ros_store.control_tree_execution_service === undefined) {
+    notify({
+      title: 'Service not available!',
+      text: 'ControlTreeExecution ROS service is not connected.',
+      type: 'error'
+    })
+    return
+  }
+  editor_store.runNewCommand(TreeExecutionCommands.SHUTDOWN)
+  ros_store.control_tree_execution_service.callService(
+    {
+      command: TreeExecutionCommands.SHUTDOWN
+    } as ControlTreeExecutionRequest,
+    (response: ControlTreeExecutionResponse) => {
+      editor_store.removeRunningCommand(TreeExecutionCommands.SHUTDOWN)
+      if (response.success) {
+        notify({
+          title: 'Tree shutdown successful!',
+          type: 'success'
+        })
+        saveFileModalHandle.open()
+      } else {
+        notify({
+          title: 'Failed to shutdown tree, cannot save now!',
+          text: response.error_message,
+          type: 'warn'
+        })
+      }
+    },
+    (failed) => {
+      notify({
+        title: 'Calling ControlTreeExecution ROS service failed!',
+        text: failed,
+        type: 'error'
+      })
+    }
+  )
+}
+
+function quickSave() {
+  if (quick_save_disable.value) {
+    return
+  }
+  window.alert("Location: " + quick_save_location.value[0] + "\nPath: " + quick_save_location.value[1])
+}
+
+function getStorageFolders() {
+  ros_store.get_storage_folders_service.callService(
+    {} as GetStorageFoldersRequest,
+    (response: GetStorageFoldersResponse) => {
+      storage_folders.value = response.storage_folders
+    },
+    (error: string) => {
+      notify({
+        title: 'Failed to call GetStorageFolders service!',
+        text: error,
+        type: 'error'
+      })
+    }
+  )
+}
+
+onMounted(() => {
+  getStorageFolders()
+})
+
+</script>
+
+<template>
+  <button
+    class="btn btn-primary"
+    title="New tree"
+    :disabled="editor_store.selected_subtree.is_subtree"
+    @click="() => newTree()"
+  >
+    <FontAwesomeIcon icon="fa-solid fa-file" aria-hidden="true" />
+    <span class="ms-1 hide-button-text">New</span>
+  </button>
+  <div class="btn-group btn-spaced" role="group">
+    <button
+      id="btnGroupDrop1"
+      type="button"
+      class="btn btn-primary dropdown-toggle"
+      data-bs-toggle="dropdown"
+      aria-expanded="false"
+      :disabled="editor_store.selected_subtree.is_subtree"
+    >
+      <FontAwesomeIcon icon="fa-solid fa-folder" aria-hidden="true" />
+      <span class="ms-1 hide-button-text">Load</span>
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="btnGroupDrop1">
+      <li>
+        <button
+          class="dropdown-item btn btn-primary"
+          title="Load from package"
+          :disabled="editor_store.selected_subtree.is_subtree"
+          @click="() => loadFromPackage()"
+        >
+          <FontAwesomeIcon icon="fa-solid fa-folder-tree" aria-hidden="true" />
+          <span class="ms-1">Package</span>
+        </button>
+      </li>
+      <li>
+        <button
+          class="dropdown-item btn btn-primary"
+          title="Load from file"
+          :disabled="editor_store.selected_subtree.is_subtree"
+          @click="() => loadFromFile()"
+        >
+          <FontAwesomeIcon icon="fa-solid fa-folder-open" aria-hidden="true" />
+          <span className="ms-1">File</span>
+        </button>
+      </li>
+    </ul>
+  </div>
+  <button
+    class="btn btn-primary btn-spaced"
+    title="Quick Save to remote"
+    :disabled="editor_store.selected_subtree.is_subtree || quick_save_disable"
+    @click="quickSave"
+  >
+    QS
+    <span class="ms-1 hide-button-text">Quick Save</span>
+  </button>
+  <button
+    class="btn btn-primary btn-spaced"
+    title="Save to remote"
+    :disabled="editor_store.selected_subtree.is_subtree"
+    @click="() => saveToFile()"
+  >
+    <FontAwesomeIcon icon="fa-solid fa-save" aria-hidden="true" />
+    <span class="ms-1 hide-button-text">Save</span>
+  </button>
+</template>
+
+

--- a/src/components/modals/LoadFileModal.vue
+++ b/src/components/modals/LoadFileModal.vue
@@ -37,6 +37,7 @@ import type {
   LoadTreeFromPathResponse
 } from '@/types/services/LoadTreeFromPath'
 import { notify } from '@kyvg/vue3-notification'
+import { useEditorStore } from '@/stores/editor'
 
 const props = defineProps<{
   fromPackages: boolean
@@ -46,6 +47,7 @@ const emit = defineEmits<{
   (e: 'close'): void
 }>()
 
+const editor_store = useEditorStore()
 const ros_store = useROSStore()
 
 const treatable_errors: string[] = []
@@ -91,6 +93,7 @@ function loadTree() {
           text: file_path.value,
           type: 'success'
         })
+        editor_store.resetQuickSaveLocation()
         emit('close')
       } else {
         notify({
@@ -128,6 +131,7 @@ function loadTree() {
                 text: file_path.value,
                 type: 'success'
               })
+              editor_store.resetQuickSaveLocation()
               emit('close')
             } else {
               notify({

--- a/src/components/modals/SaveFileModal.vue
+++ b/src/components/modals/SaveFileModal.vue
@@ -112,6 +112,7 @@ function saveTree() {
           text: response.file_path,
           type: 'success'
         })
+        editor_store.setQuickSaveLocation(response.file_path)
         emit('close')
       } else {
         if (
@@ -150,6 +151,7 @@ function saveTree() {
                 text: response.file_path,
                 type: 'success'
               })
+              editor_store.setQuickSaveLocation(response.file_path)
               emit('close')
             } else {
               notify({

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,10 +90,11 @@ import {
   faPause,
   faLeaf,
   faLink,
-  faNetworkWired
+  faNetworkWired,
+  faBookmark
 } from '@fortawesome/free-solid-svg-icons'
 
-import { faSun as faSunAlt, faMoon as faMoonAlt } from '@fortawesome/free-regular-svg-icons'
+import { faSun as faSunAlt, faMoon as faMoonAlt, faSave as faSaveAlt } from '@fortawesome/free-regular-svg-icons'
 
 library.add(
   faSync,
@@ -137,7 +138,9 @@ library.add(
   faPause,
   faLeaf,
   faNetworkWired,
-  faLink
+  faLink,
+  faSaveAlt,
+  faBookmark
 )
 
 const app = createApp(App)

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -94,6 +94,8 @@ export const useEditorStore = defineStore(
     subtree_states.value.map((tree) => tree.name)
   )*/
 
+    const quick_save_location = ref<string>('')
+
     const selected_edge = ref<Wiring | undefined>(undefined)
 
     const is_layer_mode = ref<boolean>(false)
@@ -185,6 +187,18 @@ export const useEditorStore = defineStore(
     }
   }*/
 
+    function setQuickSaveLocation(path: string) {
+      if (path.startsWith('file://')) {
+        quick_save_location.value = path
+      } else {
+        quick_save_location.value = 'file://' + path
+      }
+    }
+
+    function resetQuickSaveLocation() {
+      quick_save_location.value = ''
+    }
+
     function selectEdge(edge: Wiring) {
       selected_edge.value = edge
     }
@@ -224,12 +238,15 @@ export const useEditorStore = defineStore(
       cycleEditorSkin,
       selected_edge,
       selectEdge,
-      unselectEdge
+      unselectEdge,
+      quick_save_location,
+      setQuickSaveLocation,
+      resetQuickSaveLocation
     }
   },
   {
     persist: {
-      pick: ['publish_data', 'publish_subtrees'],
+      pick: ['publish_data', 'publish_subtrees', 'quick_save_location'],
       storage: sessionStorage
     }
   }


### PR DESCRIPTION
Add a quick save feature that saves a file to its last storage location (promting to confirm the overwrite).

This last storage location is:
- The path where the current tree was loaded from
- The path that the current tree was last saved to
Whichever happened most recently.

If there is no last storage location known, the feature is disabled

This relies on the backend changes made in https://github.com/fzi-forschungszentrum-informatik/ros2_ros_bt_py/pull/199 and should only be merged after those changes.